### PR TITLE
Ruby 1.9.x Compatibility

### DIFF
--- a/lib/unix_crypt.rb
+++ b/lib/unix_crypt.rb
@@ -95,7 +95,7 @@ module UnixCrypt
       dp = digest.digest(password * password.length)
       p = dp * (password.length/length) + dp[0...password.length % length]
 
-      ds = digest.digest(salt * (16 + a.bytes.to_a[0]))
+      ds = digest.digest(salt * (16 + a.bytes.first))
       s = ds * (salt.length/length) + ds[0...salt.length % length]
 
       rounds.times do |index|


### PR DESCRIPTION
None of the tests passed for me on 1.9.2p0

I needed to add a conversion on the input string to byte array in base64encode, and the same thing in the hash method of SHABase.

Tested on Ruby 1.8.7p249 & 1.9.2p0
