### PR TITLE
Avoid uninitialised variable warning for io_console check

### DIFF
--- a/lib/unix_crypt/command_line.rb
+++ b/lib/unix_crypt/command_line.rb
@@ -1,5 +1,6 @@
 require 'optparse'
 require 'ostruct'
+$no_io_console = false
 begin
   require 'io/console'
 rescue LoadError


### PR DESCRIPTION
In newer Rubys, io_console should be available, and hence $no_io_console may be an uninitialised variable.

Just set it to false and change to true if we can't find io_console.