### PR TITLE
Fix deprecation warnings in ruby 3.4

### DIFF
--- a/lib/unix_crypt/base.rb
+++ b/lib/unix_crypt/base.rb
@@ -26,7 +26,7 @@ class UnixCrypt::Base
   def self.bit_specified_base64encode(input)
     b64 = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
     input = input.bytes.to_a
-    output = ""
+    output = +""
     byte_indexes.each do |i3, i2, i1|
       b1, b2, b3 = i1 && input[i1] || 0, i2 && input[i2] || 0, i3 && input[i3] || 0
       output <<

--- a/lib/unix_crypt/command_line.rb
+++ b/lib/unix_crypt/command_line.rb
@@ -103,7 +103,7 @@ class UnixCrypt::CommandLine
       result = $stdin.noecho(&:gets)
     end
     $stderr.puts
-    result
+    +result
   end
 
   def password_warning


### PR DESCRIPTION
In ruby 3.4 all strings are treated as if frozen by default, and will emit a deprecation warning otherwise: https://docs.ruby-lang.org/en/3.4/NEWS_md.html

Caveats:
1. I just fixed the issues found by the test suite, I didn't do a review of the codebase.
2. I'm not sure what ruby versions support [String#+@](https://ruby-doc.org/3.4.1/String.html#method-i-2B-40)